### PR TITLE
feat: add office-tools extension

### DIFF
--- a/extensions/office-tools/README.md
+++ b/extensions/office-tools/README.md
@@ -1,0 +1,69 @@
+# Office Tools
+
+A [Finch](https://finchwork.app) mini tool that enables **reading, creating, and editing Word, Excel, and PowerPoint files** directly from the Finch agent.
+
+Powered by [OfficeCLI](https://github.com/iOfficeAI/OfficeCLI) — the world's first Office suite built for AI agents.
+
+## Requirements
+
+- [OfficeCLI](https://github.com/iOfficeAI/OfficeCLI) binary
+
+  The agent will automatically call `setup_officecli` to download and install it on first use. No manual installation needed.
+
+  Manual install alternatives:
+  ```bash
+  # macOS / Linux
+  curl -fsSL https://d.officecli.ai/install.sh | bash
+
+  # or Homebrew
+  brew install officecli
+
+  # or npm
+  npm install -g @officecli/officecli
+  ```
+
+## Features
+
+| Tool | Description |
+|------|-------------|
+| `setup_officecli` | Download and install OfficeCLI (one-time setup) |
+| `check_officecli` | Check if OfficeCLI is installed |
+| `read_office_file` | Read .docx, .xlsx, .pptx content (outline / html / text / issues / stats) |
+| `create_office_file` | Create new empty Office files |
+| `modify_office_file` | Add, set, remove, move elements, find & replace |
+| `get_office_element` | Get structured JSON for a specific element |
+| `inspect_office_file` | Validate file, query OfficeCLI help system |
+| `preview_office_file` | Live preview in browser + click-to-select elements |
+| `save_office_file` | Save and close a file |
+
+### Supported File Types
+
+- **Word** (.docx) — full document reading and editing
+- **Excel** (.xlsx) — spreadsheets, formulas, charts, pivot tables
+- **PowerPoint** (.pptx) — presentations with slides, shapes, charts, images
+
+## Usage
+
+Once installed and enabled in Finch, just ask the agent:
+
+- _"Read my report.docx"_
+- _"Create a new presentation called demo.pptx with 3 slides"_
+- _"Add a chart to the first slide"_
+- _"Edit cell B3 in data.xlsx to be 42"_
+- _"Check if OfficeCLI is installed"_
+
+## Permissions
+
+- `filesystem: readwrite` — read and write Office files
+- `shell: true` — run the `officecli` binary
+
+## Development
+
+```bash
+npm install
+npm run build
+```
+
+## License
+
+MIT

--- a/extensions/office-tools/README.zh-CN.md
+++ b/extensions/office-tools/README.zh-CN.md
@@ -1,0 +1,125 @@
+# Office Tools
+
+[Finch](https://finchwork.app) 扩展，让 Finch Agent 能够直接读取、创建和编辑 Word、Excel、PowerPoint 文件。
+
+底层使用 [OfficeCLI](https://github.com/iOfficeAI/OfficeCLI) —— 专为 AI Agent 设计的 Office 套件命令行工具。
+
+## 前置条件
+
+- [OfficeCLI](https://github.com/iOfficeAI/OfficeCLI) 二进制文件
+
+  Agent 会在首次使用时自动调用 `setup_officecli` 下载安装，无需手动操作。
+
+  手动安装方式：
+  ```bash
+  curl -fsSL https://d.officecli.ai/install.sh | bash
+  # 或
+  brew install officecli
+  # 或
+  npm install -g @officecli/officecli
+  ```
+
+## 功能
+
+| 工具 | 说明 |
+|------|------|
+| `setup_officecli` | 下载安装 OfficeCLI（一次性设置） |
+| `check_officecli` | 检查 OfficeCLI 安装状态 |
+| `read_office_file` | 读取 .docx、.xlsx、.pptx 内容（大纲/HTML/纯文本/问题/统计） |
+| `create_office_file` | 创建新文件 |
+| `modify_office_file` | 增、改、删、移动元素，查找替换 |
+| `get_office_element` | 获取元素的 JSON 结构化数据 |
+| `inspect_office_file` | 校验文件、查询 OfficeCLI 帮助文档 |
+| `preview_office_file` | 实时预览 + 浏览器点击选择元素 |
+| `save_office_file` | 保存并关闭文件 |
+
+### 支持的文件类型
+
+- **Word** (.docx) — 完整文档读写编辑
+- **Excel** (.xlsx) — 电子表格、公式、图表、透视表
+- **PowerPoint** (.pptx) — 演示文稿，含幻灯片、形状、图表、动画
+
+## 预览功能
+
+支持三种格式的实时预览：
+
+| 格式 | 预览行为 |
+|------|---------|
+| PPT | 创建/编辑时**自动启动**预览 |
+| Word | 编辑时**询问用户**是否需要预览 |
+| Excel | 编辑时**询问用户**是否需要预览 |
+
+预览启动后会自动打开浏览器，编辑文件时浏览器自动刷新。可以在浏览器里点击选中元素，然后通过工具获取选中元素的路径进行编辑。
+
+## 使用示例
+
+安装并启用后，直接跟 Finch 说：
+
+- _"帮我创建一个 Q4 汇报 PPT"_
+- _"读取 report.docx 看看结构"_
+- _"在 data.xlsx 的 B3 单元格写入 42"_
+- _"给 PPT 第一页添加一个标题"_
+- _"帮我预览一下这个 Excel"_
+
+## 提示词指南
+
+扩展内置了 34 个提示词指南，覆盖常见办公场景：
+
+### 通用
+- 检查 OfficeCLI 安装状态
+- 查询 OfficeCLI 帮助文档
+
+### Word
+- 读取文档结构
+- 创建正式报告（含目录、页眉页脚）
+- 创建会议纪要
+- 创建提案文档
+- 创建合同协议
+- 创建简历
+- 添加表格和图片
+- 添加批注和修订
+- 批量查找替换
+
+### Excel
+- 读取表格结构
+- 创建预算追踪器
+- 创建销售仪表盘
+- 创建数据透视表
+- 创建成绩册
+- 创建财务模型
+- 创建项目追踪器
+- 添加公式和图表
+- 排序和筛选
+
+### PowerPoint
+- 读取幻灯片大纲
+- 创建 Pitch Deck
+- 创建季度业务回顾
+- 创建产品发布会演示
+- 创建培训演示
+- 创建数据可视化演示
+- 添加动画和过渡
+- 移动/克隆/重排幻灯片
+- 批量修改（统一字体、加 Logo）
+
+### 预览
+- 预览并点击编辑（通用）
+- 预览 Word 文档
+- 预览 Excel 表格
+- 预览 PowerPoint
+
+## 权限
+
+- `filesystem: readwrite` — 读写 Office 文件
+- `shell: true` — 运行 `officecli` 二进制文件
+
+## 开发
+
+```bash
+npm install
+npm run build
+```
+
+## 许可证
+
+MIT

--- a/extensions/office-tools/i18n/en-US.json
+++ b/extensions/office-tools/i18n/en-US.json
@@ -1,0 +1,177 @@
+{
+  "name": "Office Tools",
+  "description": "Read, create, edit Word, Excel, and PowerPoint files",
+  "systemPrompt": "When the user needs to work with Office documents (Word .docx, Excel .xlsx, PowerPoint .pptx), prefer the Office Tools extension. It wraps OfficeCLI — a single-binary Office suite for AI agents.\n\nStrategy: L1 (read & inspect) → L2 (edit). Start with `read_office_file` to understand structure, then use `modify_office_file` to make changes. When unsure about property names or syntax, use `inspect_office_file` with a help query instead of guessing.\n\nSetup: If OfficeCLI is not installed, call `setup_officecli` to download and install it automatically. This is a one-time setup. If `check_officecli` shows OfficeCLI is not available, always suggest calling `setup_officecli` first.\n\nLive preview rules:\n- PowerPoint (.pptx): ALWAYS start a live preview (`preview_office_file(action=start)`) when creating or editing a PPT. PPT is a visual medium — the user needs to see the result in real time. After each `modify_office_file` call, the browser auto-refreshes. When the user clicks an element in the browser, use `preview_office_file(action=selected)` to inspect it.\n- Word (.docx) and Excel (.xlsx): Do NOT auto-start preview. Instead, ask the user: 'Would you like a live preview so you can click on elements to inspect them?' If yes, start preview. If no, continue without.\n- When done with all edits and the user no longer needs preview, call `preview_office_file(action=stop)` to shut down the server.",
+  "promptGuides": {
+    "setup-officecli": {
+      "title": "Set up OfficeCLI",
+      "description": "Check and install OfficeCLI if needed.",
+      "prompt": "Check if OfficeCLI is installed using check_officecli. If not installed, call setup_officecli to download and install it."
+    },
+    "inspect-help": {
+      "title": "Look up OfficeCLI help",
+      "description": "Query OfficeCLI help for property syntax.",
+      "prompt": "Look up how to add a chart to a PowerPoint slide using OfficeCLI help."
+    },
+    "read-docx": {
+      "title": "Read a Word document",
+      "description": "Read a .docx file and display its structure.",
+      "prompt": "Read outline.docx and show me the document structure in outline view. Then start a live preview so I can click on paragraphs and tables to inspect them."
+    },
+    "read-pptx": {
+      "title": "Read a PowerPoint",
+      "description": "Read a .pptx file and display its structure.",
+      "prompt": "Read deck.pptx and show me the slide outline. Then start a live preview so I can click on elements."
+    },
+    "read-xlsx": {
+      "title": "Read an Excel file",
+      "description": "Read a .xlsx file and display its structure.",
+      "prompt": "Read data.xlsx and show me the outline. Then start a live preview so I can click on cells and sheets to inspect them."
+    },
+    "create-report": {
+      "title": "Create a formal report",
+      "description": "Create a Word document with TOC, headers, footers, page numbers.",
+      "prompt": "Create a formal report called annual-report.docx. Add a title page with 'Annual Report 2025', a table of contents, 3 sections with headings and body text, headers with page numbers, and a footer with the company name."
+    },
+    "create-minutes": {
+      "title": "Create meeting minutes",
+      "description": "Create a Word document for meeting minutes.",
+      "prompt": "Create meeting-minutes.docx with a header 'Meeting Minutes', date, attendees list, agenda items, discussion points, and action items with owners and deadlines."
+    },
+    "create-proposal": {
+      "title": "Create a proposal",
+      "description": "Create a Word proposal document.",
+      "prompt": "Create proposal.docx with sections: Executive Summary, Problem Statement, Proposed Solution, Timeline, Budget, and Conclusion. Use professional formatting with headings and bullet points."
+    },
+    "create-contract": {
+      "title": "Create a contract",
+      "description": "Create a Word contract or agreement.",
+      "prompt": "Create contract.docx with sections: Parties, Scope of Work, Payment Terms, Timeline, Confidentiality, Termination, and Signatures. Use formal language and proper formatting."
+    },
+    "create-resume": {
+      "title": "Create a resume",
+      "description": "Create a professional resume in Word.",
+      "prompt": "Create resume.docx with sections: Contact Info, Summary, Experience (3 jobs), Education, Skills, and Certifications. Use clean formatting with consistent fonts."
+    },
+    "create-pptx-pitch": {
+      "title": "Create a pitch deck",
+      "description": "Create a startup pitch deck in PowerPoint.",
+      "prompt": "Create pitch-deck.pptx with 10 slides: Title, Problem, Solution, Market Size, Business Model, Traction, Team, Financials, Ask, and Contact. Use a dark theme with professional colors."
+    },
+    "create-pptx-qbr": {
+      "title": "Create a quarterly review",
+      "description": "Create a quarterly business review presentation.",
+      "prompt": "Create qbr.pptx with slides: Title, Agenda, Key Metrics, Revenue Breakdown, Customer Growth, Product Updates, Challenges, Next Quarter Goals. Add charts for revenue and customer data."
+    },
+    "create-pptx-product": {
+      "title": "Create a product launch deck",
+      "description": "Create a product launch presentation.",
+      "prompt": "Create product-launch.pptx with slides: Title, Product Overview, Key Features (3 slides), Demo, Pricing, Market Opportunity, Competitive Analysis, Call to Action. Use modern design with images."
+    },
+    "create-pptx-training": {
+      "title": "Create a training deck",
+      "description": "Create a training or onboarding presentation.",
+      "prompt": "Create training.pptx with slides: Title, Agenda, Company Overview, Role Description, Tools & Systems, Processes, Best Practices, Q&A. Add speaker notes to each slide."
+    },
+    "create-pptx-charts": {
+      "title": "Create a presentation with charts",
+      "description": "Create a PowerPoint with data visualization.",
+      "prompt": "Create dashboard.pptx with slides containing: a bar chart for monthly revenue, a pie chart for market share, a line chart for growth trends, and a table summarizing key metrics."
+    },
+    "create-xlsx-budget": {
+      "title": "Create a budget tracker",
+      "description": "Create an Excel budget spreadsheet.",
+      "prompt": "Create budget.xlsx with sheets: Income (salary, investments, other), Expenses (housing, food, transport, utilities, entertainment), and Summary with totals, formulas for each category, and a net income calculation."
+    },
+    "create-xlsx-dashboard": {
+      "title": "Create a sales dashboard",
+      "description": "Create an Excel sales dashboard with charts.",
+      "prompt": "Create sales-dashboard.xlsx with raw data sheet (100 rows of sales data with columns: Date, Product, Region, Amount, Units), a pivot table, and charts for revenue by region and monthly trends."
+    },
+    "create-xlsx-pivot": {
+      "title": "Create a pivot table",
+      "description": "Create an Excel pivot table from data.",
+      "prompt": "Read data.xlsx, then create a pivot table on a new sheet that summarizes sales by Region and Product, with totals and percentages."
+    },
+    "create-xlsx-gradebook": {
+      "title": "Create a gradebook",
+      "description": "Create an Excel gradebook with formulas.",
+      "prompt": "Create gradebook.xlsx with columns: Student Name, Assignment 1-5, Midterm, Final, Total (weighted formula), Grade (letter), and conditional formatting for pass/fail."
+    },
+    "create-xlsx-financial": {
+      "title": "Create a financial model",
+      "description": "Create an Excel financial model.",
+      "prompt": "Create financial-model.xlsx with sheets: Assumptions, Revenue Projections (5 years), Cost Structure, P&L Statement, Cash Flow, and Summary with key metrics and charts."
+    },
+    "create-xlsx-tracker": {
+      "title": "Create a project tracker",
+      "description": "Create an Excel project tracker.",
+      "prompt": "Create project-tracker.xlsx with columns: Task, Owner, Start Date, End Date, Status, Priority, Progress %. Add conditional formatting for status colors and a summary dashboard."
+    },
+    "edit-word-tables": {
+      "title": "Edit Word tables",
+      "description": "Add and format tables in a Word document.",
+      "prompt": "Read report.docx, then add a 4x4 table after the first paragraph with headers: Category, Q1, Q2, Q3. Add data rows and format the header row bold with a blue background."
+    },
+    "edit-word-images": {
+      "title": "Add images to Word",
+      "description": "Add images and captions to a Word document.",
+      "prompt": "Read report.docx, then add an image called chart.png after the second paragraph. Add a caption below the image: 'Figure 1: Revenue Growth'."
+    },
+    "edit-word-comments": {
+      "title": "Add comments to Word",
+      "description": "Add comments and track changes.",
+      "prompt": "Read draft.docx, then add comments to paragraphs that need revision. Add a comment 'Please expand this section' to the third paragraph."
+    },
+    "edit-pptx-animations": {
+      "title": "Add animations to PPT",
+      "description": "Add animations and transitions to slides.",
+      "prompt": "Read deck.pptx, then add a fade-in animation to the title shape on slide 1, a fly-in animation to the bullet points on slide 2, and a morph transition between all slides."
+    },
+    "edit-pptx-layout": {
+      "title": "Rearrange PPT slides",
+      "description": "Move, clone, and rearrange slides.",
+      "prompt": "Read deck.pptx, then clone slide 1 and move it to the end. Change the title of the cloned slide to 'Thank You'."
+    },
+    "edit-xlsx-formulas": {
+      "title": "Add formulas to Excel",
+      "description": "Add formulas and calculations.",
+      "prompt": "Read data.xlsx, then add a SUM formula in the total row, an AVERAGE formula for each column, and conditional formatting to highlight cells above 1000."
+    },
+    "edit-xlsx-charts": {
+      "title": "Add charts to Excel",
+      "description": "Create charts from spreadsheet data.",
+      "prompt": "Read data.xlsx, then create a bar chart showing revenue by month, a pie chart showing market share by product, and a line chart showing growth trends."
+    },
+    "edit-xlsx-sort": {
+      "title": "Sort and filter Excel data",
+      "description": "Sort and filter spreadsheet data.",
+      "prompt": "Read data.xlsx, then sort the data by column C in descending order. Add an autofilter to the header row."
+    },
+    "preview-click-edit": {
+      "title": "Preview and click to edit",
+      "description": "Start live preview, click elements, and edit them.",
+      "prompt": "Start a live preview of my document. After I click on an element, get the selected element and change its color to red."
+    },
+    "preview-word": {
+      "title": "Preview a Word document",
+      "description": "Start live preview of a Word document for visual editing.",
+      "prompt": "Start a live preview of report.docx. I want to click on paragraphs and tables to inspect their formatting and make changes."
+    },
+    "preview-excel": {
+      "title": "Preview an Excel spreadsheet",
+      "description": "Start live preview of an Excel spreadsheet.",
+      "prompt": "Start a live preview of data.xlsx. I want to click on cells and sheets to inspect their values and formulas."
+    },
+    "bulk-edit-word": {
+      "title": "Bulk edit Word document",
+      "description": "Find and replace text across a Word document.",
+      "prompt": "Read report.docx, then find all instances of 'draft' and replace with 'final'. Also bold all instances of 'important'."
+    },
+    "bulk-edit-pptx": {
+      "title": "Bulk edit PowerPoint",
+      "description": "Apply changes across multiple slides.",
+      "prompt": "Read deck.pptx, then change the font to Arial and size to 24pt on all shapes across all slides. Add a company logo to the bottom-right of each slide."
+    }
+  }
+}

--- a/extensions/office-tools/i18n/zh-CN.json
+++ b/extensions/office-tools/i18n/zh-CN.json
@@ -1,0 +1,177 @@
+{
+  "name": "Office Tools",
+  "description": "读取、创建、编辑 Word、Excel、PowerPoint 文件",
+  "systemPrompt": "当用户需要处理 Office 文档（Word .docx、Excel .xlsx、PowerPoint .pptx）时，优先使用 Office Tools 扩展。底层使用 OfficeCLI —— 专为 AI Agent 设计的 Office 套件命令行工具。\n\n策略：L1（读取与检查）→ L2（编辑）。先用 `read_office_file` 了解文档结构，再用 `modify_office_file` 进行修改。不确定属性名或语法时，用 `inspect_office_file` 查询帮助文档，不要猜测。\n\n安装：如果 OfficeCLI 未安装，调用 `setup_officecli` 自动下载安装。这是一次性设置。如果 `check_officecli` 显示 OfficeCLI 不可用，始终建议先调用 `setup_officecli`。\n\n实时预览规则：\n- PowerPoint (.pptx)：创建或编辑 PPT 时**必须**启动实时预览（`preview_office_file(action=start)`）。PPT 是视觉媒介，用户需要实时看到效果。每次 `modify_office_file` 后浏览器自动刷新。用户在浏览器里点击元素时，用 `preview_office_file(action=selected)` 检查。\n- Word (.docx) 和 Excel (.xlsx)：**不要**自动启动预览。改为询问用户：'需要启动实时预览吗？你可以在浏览器里点击元素来检查。'如果用户说要，就启动；如果不要，继续编辑。\n- 编辑完成且用户不再需要预览时，调用 `preview_office_file(action=stop)` 关闭服务器。",
+  "promptGuides": {
+    "setup-officecli": {
+      "title": "设置 OfficeCLI",
+      "description": "检查并在需要时安装 OfficeCLI。",
+      "prompt": "先用 check_officecli 检查 OfficeCLI 是否已安装。如果没有安装，调用 setup_officecli 下载安装。"
+    },
+    "inspect-help": {
+      "title": "查询 OfficeCLI 帮助",
+      "description": "查询 OfficeCLI 帮助文档获取属性语法。",
+      "prompt": "查询如何在 PowerPoint 幻灯片中添加图表，使用 OfficeCLI 帮助。"
+    },
+    "read-docx": {
+      "title": "读取 Word 文档",
+      "description": "读取 .docx 文件并显示结构。",
+      "prompt": "读取 outline.docx 并以大纲视图显示文档结构。然后启动实时预览，让我点击段落和表格来检查它们。"
+    },
+    "read-pptx": {
+      "title": "读取 PowerPoint",
+      "description": "读取 .pptx 文件并显示结构。",
+      "prompt": "读取 deck.pptx 并显示幻灯片大纲。然后启动实时预览，让我点击元素。"
+    },
+    "read-xlsx": {
+      "title": "读取 Excel 文件",
+      "description": "读取 .xlsx 文件并显示结构。",
+      "prompt": "读取 data.xlsx 并显示大纲。然后启动实时预览，让我点击单元格和工作表来检查它们。"
+    },
+    "create-report": {
+      "title": "创建正式报告",
+      "description": "创建含目录、页眉页脚、页码的 Word 文档。",
+      "prompt": "创建一个名为 annual-report.docx 的正式报告。添加标题页 '年度报告 2025'，目录，3 个带标题和正文的章节，带页码的页眉，和带公司名称的页脚。"
+    },
+    "create-minutes": {
+      "title": "创建会议纪要",
+      "description": "创建会议纪要 Word 文档。",
+      "prompt": "创建 meeting-minutes.docx，包含标题 '会议纪要'，日期，参会人员列表，议程事项，讨论要点，和带负责人和截止日期的行动事项。"
+    },
+    "create-proposal": {
+      "title": "创建提案文档",
+      "description": "创建 Word 提案文档。",
+      "prompt": "创建 proposal.docx，包含章节：执行摘要，问题陈述，解决方案，时间线，预算，和结论。使用专业格式和标题、要点。"
+    },
+    "create-contract": {
+      "title": "创建合同",
+      "description": "创建 Word 合同或协议。",
+      "prompt": "创建 contract.docx，包含章节：各方，工作范围，付款条款，时间线，保密条款，终止条款，和签名。使用正式语言和适当格式。"
+    },
+    "create-resume": {
+      "title": "创建简历",
+      "description": "创建专业 Word 简历。",
+      "prompt": "创建 resume.docx，包含章节：联系方式，摘要，工作经历（3 份工作），教育背景，技能，和证书。使用简洁格式和一致字体。"
+    },
+    "create-pptx-pitch": {
+      "title": "创建 Pitch Deck",
+      "description": "创建创业融资演示文稿。",
+      "prompt": "创建 pitch-deck.pptx，包含 10 页幻灯片：标题，问题，解决方案，市场规模，商业模式，增长数据，团队，财务，融资需求，和联系方式。使用深色主题和专业配色。"
+    },
+    "create-pptx-qbr": {
+      "title": "创建季度业务回顾",
+      "description": "创建季度业务回顾演示文稿。",
+      "prompt": "创建 qbr.pptx，包含幻灯片：标题，议程，关键指标，收入分布，客户增长，产品更新，挑战，下季度目标。为收入和客户数据添加图表。"
+    },
+    "create-pptx-product": {
+      "title": "创建产品发布会演示",
+      "description": "创建产品发布会演示文稿。",
+      "prompt": "创建 product-launch.pptx，包含幻灯片：标题，产品概述，核心功能（3 页），演示，定价，市场机会，竞品分析，行动号召。使用现代设计和图片。"
+    },
+    "create-pptx-training": {
+      "title": "创建培训演示",
+      "description": "创建培训或入职演示文稿。",
+      "prompt": "创建 training.pptx，包含幻灯片：标题，议程，公司概述，角色描述，工具和系统，流程，最佳实践，问答。为每页幻灯片添加演讲者备注。"
+    },
+    "create-pptx-charts": {
+      "title": "创建含图表的演示",
+      "description": "创建带数据可视化的 PowerPoint。",
+      "prompt": "创建 dashboard.pptx，包含：月度收入柱状图，市场份额饼图，增长趋势折线图，和汇总关键指标的表格。"
+    },
+    "create-xlsx-budget": {
+      "title": "创建预算追踪器",
+      "description": "创建 Excel 预算表格。",
+      "prompt": "创建 budget.xlsx，包含工作表：收入（工资、投资、其他），支出（住房、食物、交通、水电、娱乐），和汇总表，含各类别总计、公式和净收入计算。"
+    },
+    "create-xlsx-dashboard": {
+      "title": "创建销售仪表盘",
+      "description": "创建带图表的 Excel 销售仪表盘。",
+      "prompt": "创建 sales-dashboard.xlsx，包含原始数据表（100 行销售数据，列：日期、产品、区域、金额、数量），数据透视表，和按区域及月度趋势的收入图表。"
+    },
+    "create-xlsx-pivot": {
+      "title": "创建数据透视表",
+      "description": "从数据创建 Excel 数据透视表。",
+      "prompt": "读取 data.xlsx，然后在新工作表上创建数据透视表，按区域和产品汇总销售数据，含总计和百分比。"
+    },
+    "create-xlsx-gradebook": {
+      "title": "创建成绩册",
+      "description": "创建带公式的 Excel 成绩册。",
+      "prompt": "创建 gradebook.xlsx，包含列：学生姓名，作业 1-5，期中，期末，总分（加权公式），等级（字母），和及格/不及格的条件格式。"
+    },
+    "create-xlsx-financial": {
+      "title": "创建财务模型",
+      "description": "创建 Excel 财务模型。",
+      "prompt": "创建 financial-model.xlsx，包含工作表：假设，收入预测（5 年），成本结构，利润表，现金流量表，和汇总表含关键指标和图表。"
+    },
+    "create-xlsx-tracker": {
+      "title": "创建项目追踪器",
+      "description": "创建 Excel 项目追踪器。",
+      "prompt": "创建 project-tracker.xlsx，包含列：任务，负责人，开始日期，结束日期，状态，优先级，进度百分比。为状态颜色添加条件格式和汇总仪表盘。"
+    },
+    "edit-word-tables": {
+      "title": "编辑 Word 表格",
+      "description": "在 Word 文档中添加和格式化表格。",
+      "prompt": "读取 report.docx，然后在第一段后添加一个 4x4 表格，标题为：类别，Q1，Q2，Q3。添加数据行，标题行加粗并使用蓝色背景。"
+    },
+    "edit-word-images": {
+      "title": "在 Word 中添加图片",
+      "description": "在 Word 文档中添加图片和图注。",
+      "prompt": "读取 report.docx，然后在第二段后添加一张名为 chart.png 的图片。在图片下方添加图注：'图 1：收入增长'。"
+    },
+    "edit-word-comments": {
+      "title": "添加 Word 批注",
+      "description": "添加批注和修订跟踪。",
+      "prompt": "读取 draft.docx，然后为需要修改的段落添加批注。在第三段添加批注 '请扩展此部分'。"
+    },
+    "edit-pptx-animations": {
+      "title": "为 PPT 添加动画",
+      "description": "为幻灯片添加动画和过渡。",
+      "prompt": "读取 deck.pptx，然后为第一页幻灯片的标题形状添加淡入动画，为第二页的要点添加飞入动画，为所有幻灯片之间添加 Morph 过渡。"
+    },
+    "edit-pptx-layout": {
+      "title": "重排 PPT 幻灯片",
+      "description": "移动、克隆和重排幻灯片。",
+      "prompt": "读取 deck.pptx，然后克隆第一页幻灯片并移到最后。将克隆的幻灯片标题改为 '谢谢'。"
+    },
+    "edit-xlsx-formulas": {
+      "title": "添加 Excel 公式",
+      "description": "添加公式和计算。",
+      "prompt": "读取 data.xlsx，然后在总计行添加 SUM 公式，为每列添加 AVERAGE 公式，并为超过 1000 的单元格添加条件格式高亮。"
+    },
+    "edit-xlsx-charts": {
+      "title": "添加 Excel 图表",
+      "description": "从表格数据创建图表。",
+      "prompt": "读取 data.xlsx，然后创建月度收入柱状图，按产品市场份额饼图，和增长趋势折线图。"
+    },
+    "edit-xlsx-sort": {
+      "title": "排序和筛选 Excel 数据",
+      "description": "排序和筛选表格数据。",
+      "prompt": "读取 data.xlsx，然后按 C 列降序排序数据。在标题行添加自动筛选。"
+    },
+    "preview-click-edit": {
+      "title": "预览并点击编辑",
+      "description": "启动实时预览，点击元素并编辑。",
+      "prompt": "启动我的文档的实时预览。当我点击一个元素后，获取选中的元素并将其颜色改为红色。"
+    },
+    "preview-word": {
+      "title": "预览 Word 文档",
+      "description": "启动 Word 文档的实时预览进行可视化编辑。",
+      "prompt": "启动 report.docx 的实时预览。我想点击段落和表格来检查它们的格式并进行修改。"
+    },
+    "preview-excel": {
+      "title": "预览 Excel 表格",
+      "description": "启动 Excel 表格的实时预览。",
+      "prompt": "启动 data.xlsx 的实时预览。我想点击单元格和工作表来检查它们的值和公式。"
+    },
+    "bulk-edit-word": {
+      "title": "批量编辑 Word 文档",
+      "description": "在 Word 文档中查找替换文本。",
+      "prompt": "读取 report.docx，然后将所有 'draft' 替换为 'final'。同时将所有 'important' 加粗。"
+    },
+    "bulk-edit-pptx": {
+      "title": "批量编辑 PowerPoint",
+      "description": "跨多张幻灯片应用更改。",
+      "prompt": "读取 deck.pptx，然后将所有幻灯片中所有形状的字体改为 Arial，字号改为 24pt。在每张幻灯片右下角添加公司 Logo。"
+    }
+  }
+}

--- a/extensions/office-tools/package-lock.json
+++ b/extensions/office-tools/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "@finch.app/office-tools",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@finch.app/office-tools",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@finch.app/minitool-api": "^0.1.10",
+        "@types/node": "^26.1.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@finch.app/minitool-api": {
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@finch.app/minitool-api/-/minitool-api-0.1.16.tgz",
+      "integrity": "sha512-rPRI3HbrfMiaklVRGAXBhHmeW8ClzMTNkWXV7d5OhfyH8VGEBLvkucTpgnjSz8wkx9QT27tWLS1eBZ3Go72EEQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.1.tgz",
+      "integrity": "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/extensions/office-tools/package.json
+++ b/extensions/office-tools/package.json
@@ -1,0 +1,265 @@
+{
+  "name": "@finch.app/office-tools",
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Office tools for Finch — read, create, edit Word, Excel, and PowerPoint files using OfficeCLI.",
+  "author": {
+    "name": "Finch Team",
+    "url": "https://finchwork.app"
+  },
+  "homepage": "https://finchwork.app",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/finchtoys/finch-releases.git",
+    "directory": "extensions/office-tools"
+  },
+  "license": "MIT",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsc -p tsconfig.json --watch"
+  },
+  "finch": {
+    "manifestVersion": 1,
+    "id": "office-tools",
+    "name": "Office Tools",
+    "description": "Office tools for Finch — read, create, edit Word, Excel, and PowerPoint files using OfficeCLI.",
+    "toolMeta": {
+      "name": "Office Tools"
+    },
+    "systemPrompt": "When the user needs to work with Office documents (Word .docx, Excel .xlsx, PowerPoint .pptx), prefer the Office Tools extension. It wraps OfficeCLI — a single-binary Office suite for AI agents.\n\nStrategy: L1 (read & inspect) → L2 (edit). Start with `read_office_file` to understand structure, then use `modify_office_file` to make changes. When unsure about property names or syntax, use `inspect_office_file` with a help query instead of guessing.\n\nSetup: If OfficeCLI is not installed, call `setup_officecli` to download and install it automatically. This is a one-time setup. If `check_officecli` shows OfficeCLI is not available, always suggest calling `setup_officecli` first.\n\nLive preview rules:\n- PowerPoint (.pptx): ALWAYS start a live preview (`preview_office_file(action=start)`) when creating or editing a PPT. PPT is a visual medium — the user needs to see the result in real time. After each `modify_office_file` call, the browser auto-refreshes. When the user clicks an element in the browser, use `preview_office_file(action=selected)` to inspect it.\n- Word (.docx) and Excel (.xlsx): Do NOT auto-start preview. Instead, ask the user: 'Would you like a live preview so you can click on elements to inspect them?' If yes, start preview. If no, continue without.\n- When done with all edits and the user no longer needs preview, call `preview_office_file(action=stop)` to shut down the server.",
+    "promptGuides": [
+      {
+        "id": "setup-officecli",
+        "title": "Set up OfficeCLI",
+        "description": "Check and install OfficeCLI if needed.",
+        "prompt": "Check if OfficeCLI is installed using check_officecli. If not installed, call setup_officecli to download and install it."
+      },
+      {
+        "id": "inspect-help",
+        "title": "Look up OfficeCLI help",
+        "description": "Query OfficeCLI help for property syntax.",
+        "prompt": "Look up how to add a chart to a PowerPoint slide using OfficeCLI help."
+      },
+      {
+        "id": "read-docx",
+        "title": "Read a Word document",
+        "description": "Read a .docx file and display its structure.",
+        "prompt": "Read outline.docx and show me the document structure in outline view. Then start a live preview so I can click on paragraphs and tables to inspect them."
+      },
+      {
+        "id": "read-pptx",
+        "title": "Read a PowerPoint",
+        "description": "Read a .pptx file and display its structure.",
+        "prompt": "Read deck.pptx and show me the slide outline. Then start a live preview so I can click on elements."
+      },
+      {
+        "id": "read-xlsx",
+        "title": "Read an Excel file",
+        "description": "Read a .xlsx file and display its structure.",
+        "prompt": "Read data.xlsx and show me the outline. Then start a live preview so I can click on cells and sheets to inspect them."
+      },
+      {
+        "id": "create-report",
+        "title": "Create a formal report",
+        "description": "Create a Word document with TOC, headers, footers, page numbers.",
+        "prompt": "Create a formal report called annual-report.docx. Add a title page with 'Annual Report 2025', a table of contents, 3 sections with headings and body text, headers with page numbers, and a footer with the company name."
+      },
+      {
+        "id": "create-minutes",
+        "title": "Create meeting minutes",
+        "description": "Create a Word document for meeting minutes.",
+        "prompt": "Create meeting-minutes.docx with a header 'Meeting Minutes', date, attendees list, agenda items, discussion points, and action items with owners and deadlines."
+      },
+      {
+        "id": "create-proposal",
+        "title": "Create a proposal",
+        "description": "Create a Word proposal document.",
+        "prompt": "Create proposal.docx with sections: Executive Summary, Problem Statement, Proposed Solution, Timeline, Budget, and Conclusion. Use professional formatting with headings and bullet points."
+      },
+      {
+        "id": "create-contract",
+        "title": "Create a contract",
+        "description": "Create a Word contract or agreement.",
+        "prompt": "Create contract.docx with sections: Parties, Scope of Work, Payment Terms, Timeline, Confidentiality, Termination, and Signatures. Use formal language and proper formatting."
+      },
+      {
+        "id": "create-resume",
+        "title": "Create a resume",
+        "description": "Create a professional resume in Word.",
+        "prompt": "Create resume.docx with sections: Contact Info, Summary, Experience (3 jobs), Education, Skills, and Certifications. Use clean formatting with consistent fonts."
+      },
+      {
+        "id": "create-pptx-pitch",
+        "title": "Create a pitch deck",
+        "description": "Create a startup pitch deck in PowerPoint.",
+        "prompt": "Create pitch-deck.pptx with 10 slides: Title, Problem, Solution, Market Size, Business Model, Traction, Team, Financials, Ask, and Contact. Use a dark theme with professional colors."
+      },
+      {
+        "id": "create-pptx-qbr",
+        "title": "Create a quarterly review",
+        "description": "Create a quarterly business review presentation.",
+        "prompt": "Create qbr.pptx with slides: Title, Agenda, Key Metrics, Revenue Breakdown, Customer Growth, Product Updates, Challenges, Next Quarter Goals. Add charts for revenue and customer data."
+      },
+      {
+        "id": "create-pptx-product",
+        "title": "Create a product launch deck",
+        "description": "Create a product launch presentation.",
+        "prompt": "Create product-launch.pptx with slides: Title, Product Overview, Key Features (3 slides), Demo, Pricing, Market Opportunity, Competitive Analysis, Call to Action. Use modern design with images."
+      },
+      {
+        "id": "create-pptx-training",
+        "title": "Create a training deck",
+        "description": "Create a training or onboarding presentation.",
+        "prompt": "Create training.pptx with slides: Title, Agenda, Company Overview, Role Description, Tools & Systems, Processes, Best Practices, Q&A. Add speaker notes to each slide."
+      },
+      {
+        "id": "create-pptx-charts",
+        "title": "Create a presentation with charts",
+        "description": "Create a PowerPoint with data visualization.",
+        "prompt": "Create dashboard.pptx with slides containing: a bar chart for monthly revenue, a pie chart for market share, a line chart for growth trends, and a table summarizing key metrics."
+      },
+      {
+        "id": "create-xlsx-budget",
+        "title": "Create a budget tracker",
+        "description": "Create an Excel budget spreadsheet.",
+        "prompt": "Create budget.xlsx with sheets: Income (salary, investments, other), Expenses (housing, food, transport, utilities, entertainment), and Summary with totals, formulas for each category, and a net income calculation."
+      },
+      {
+        "id": "create-xlsx-dashboard",
+        "title": "Create a sales dashboard",
+        "description": "Create an Excel sales dashboard with charts.",
+        "prompt": "Create sales-dashboard.xlsx with raw data sheet (100 rows of sales data with columns: Date, Product, Region, Amount, Units), a pivot table, and charts for revenue by region and monthly trends."
+      },
+      {
+        "id": "create-xlsx-pivot",
+        "title": "Create a pivot table",
+        "description": "Create an Excel pivot table from data.",
+        "prompt": "Read data.xlsx, then create a pivot table on a new sheet that summarizes sales by Region and Product, with totals and percentages."
+      },
+      {
+        "id": "create-xlsx-gradebook",
+        "title": "Create a gradebook",
+        "description": "Create an Excel gradebook with formulas.",
+        "prompt": "Create gradebook.xlsx with columns: Student Name, Assignment 1-5, Midterm, Final, Total (weighted formula), Grade (letter), and conditional formatting for pass/fail."
+      },
+      {
+        "id": "create-xlsx-financial",
+        "title": "Create a financial model",
+        "description": "Create an Excel financial model.",
+        "prompt": "Create financial-model.xlsx with sheets: Assumptions, Revenue Projections (5 years), Cost Structure, P&L Statement, Cash Flow, and Summary with key metrics and charts."
+      },
+      {
+        "id": "create-xlsx-tracker",
+        "title": "Create a project tracker",
+        "description": "Create an Excel project tracker.",
+        "prompt": "Create project-tracker.xlsx with columns: Task, Owner, Start Date, End Date, Status, Priority, Progress %. Add conditional formatting for status colors and a summary dashboard."
+      },
+      {
+        "id": "edit-word-tables",
+        "title": "Edit Word tables",
+        "description": "Add and format tables in a Word document.",
+        "prompt": "Read report.docx, then add a 4x4 table after the first paragraph with headers: Category, Q1, Q2, Q3. Add data rows and format the header row bold with a blue background."
+      },
+      {
+        "id": "edit-word-images",
+        "title": "Add images to Word",
+        "description": "Add images and captions to a Word document.",
+        "prompt": "Read report.docx, then add an image called chart.png after the second paragraph. Add a caption below the image: 'Figure 1: Revenue Growth'."
+      },
+      {
+        "id": "edit-word-comments",
+        "title": "Add comments to Word",
+        "description": "Add comments and track changes.",
+        "prompt": "Read draft.docx, then add comments to paragraphs that need revision. Add a comment 'Please expand this section' to the third paragraph."
+      },
+      {
+        "id": "edit-pptx-animations",
+        "title": "Add animations to PPT",
+        "description": "Add animations and transitions to slides.",
+        "prompt": "Read deck.pptx, then add a fade-in animation to the title shape on slide 1, a fly-in animation to the bullet points on slide 2, and a morph transition between all slides."
+      },
+      {
+        "id": "edit-pptx-layout",
+        "title": "Rearrange PPT slides",
+        "description": "Move, clone, and rearrange slides.",
+        "prompt": "Read deck.pptx, then clone slide 1 and move it to the end. Change the title of the cloned slide to 'Thank You'."
+      },
+      {
+        "id": "edit-xlsx-formulas",
+        "title": "Add formulas to Excel",
+        "description": "Add formulas and calculations.",
+        "prompt": "Read data.xlsx, then add a SUM formula in the total row, an AVERAGE formula for each column, and conditional formatting to highlight cells above 1000."
+      },
+      {
+        "id": "edit-xlsx-charts",
+        "title": "Add charts to Excel",
+        "description": "Create charts from spreadsheet data.",
+        "prompt": "Read data.xlsx, then create a bar chart showing revenue by month, a pie chart showing market share by product, and a line chart showing growth trends."
+      },
+      {
+        "id": "edit-xlsx-sort",
+        "title": "Sort and filter Excel data",
+        "description": "Sort and filter spreadsheet data.",
+        "prompt": "Read data.xlsx, then sort the data by column C in descending order. Add an autofilter to the header row."
+      },
+      {
+        "id": "preview-click-edit",
+        "title": "Preview and click to edit",
+        "description": "Start live preview, click elements, and edit them.",
+        "prompt": "Start a live preview of my document. After I click on an element, get the selected element and change its color to red."
+      },
+      {
+        "id": "preview-word",
+        "title": "Preview a Word document",
+        "description": "Start live preview of a Word document for visual editing.",
+        "prompt": "Start a live preview of report.docx. I want to click on paragraphs and tables to inspect their formatting and make changes."
+      },
+      {
+        "id": "preview-excel",
+        "title": "Preview an Excel spreadsheet",
+        "description": "Start live preview of an Excel spreadsheet.",
+        "prompt": "Start a live preview of data.xlsx. I want to click on cells and sheets to inspect their values and formulas."
+      },
+      {
+        "id": "bulk-edit-word",
+        "title": "Bulk edit Word document",
+        "description": "Find and replace text across a Word document.",
+        "prompt": "Read report.docx, then find all instances of 'draft' and replace with 'final'. Also bold all instances of 'important'."
+      },
+      {
+        "id": "bulk-edit-pptx",
+        "title": "Bulk edit PowerPoint",
+        "description": "Apply changes across multiple slides.",
+        "prompt": "Read deck.pptx, then change the font to Arial and size to 24pt on all shapes across all slides. Add a company logo to the bottom-right of each slide."
+      }
+    ],
+    "main": "dist/index.js",
+    "activationEvents": [
+      "onStartup"
+    ],
+    "contributes": {
+      "tools": true
+    },
+    "extensionType": "official",
+    "categories": [
+      "productivity"
+    ],
+    "permissions": {
+      "filesystem": "readwrite",
+      "network": false,
+      "shell": true
+    }
+  },
+  "devDependencies": {
+    "@finch.app/minitool-api": "^0.1.10",
+    "@types/node": "^26.1.0",
+    "typescript": "^5.6.0"
+  },
+  "files": [
+    "dist/",
+    "i18n/",
+    "README.md",
+    "package.json"
+  ]
+}

--- a/extensions/office-tools/src/index.ts
+++ b/extensions/office-tools/src/index.ts
@@ -1,0 +1,959 @@
+import type * as finch from 'finch';
+import { exec, execFile, execSync, spawn } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+// ── Module-level state ────────────────────────────────────────────────────
+
+let _extensionPath = '';
+/** Track running watch processes: resolved file path → { process, url, lastActivity } */
+const watchProcesses = new Map<string, { proc: ReturnType<typeof spawn>; url: string; lastActivity: number }>();
+/** Auto-stop watch after this many milliseconds of inactivity (5 minutes). */
+const WATCH_IDLE_TIMEOUT_MS = 5 * 60 * 1000;
+/** Interval to check for idle watch processes (every 60 seconds). */
+let watchIdleChecker: ReturnType<typeof setInterval> | null = null;
+
+function touchWatchActivity(filePath: string): void {
+  const entry = watchProcesses.get(filePath);
+  if (entry) entry.lastActivity = Date.now();
+}
+
+function startWatchIdleChecker(): void {
+  if (watchIdleChecker) return;
+  watchIdleChecker = setInterval(() => {
+    const now = Date.now();
+    for (const [file, entry] of watchProcesses) {
+      if (now - entry.lastActivity > WATCH_IDLE_TIMEOUT_MS) {
+        try { entry.proc.kill(); } catch { /* ignore */ }
+        try { execSync(`${getOfficeCLIBinary()} unwatch "${file}"`, { timeout: 5000, stdio: 'pipe' }); } catch { /* ignore */ }
+        watchProcesses.delete(file);
+      }
+    }
+    if (watchProcesses.size === 0 && watchIdleChecker) {
+      clearInterval(watchIdleChecker);
+      watchIdleChecker = null;
+    }
+  }, 60_000);
+}
+
+function getBinPath(): string {
+  const suffix = process.platform === 'win32' ? 'officecli.exe' : 'officecli';
+  return join(_extensionPath, 'bin', suffix);
+}
+
+function getBinDir(): string {
+  return join(_extensionPath, 'bin');
+}
+
+function getDataDir(): string {
+  return join(_extensionPath, 'data');
+}
+
+/** Resolve file path: if relative, place it in the extension's data/ directory. */
+function resolveFilePath(filePath: string): string {
+  // Already absolute — use as-is
+  if (filePath.startsWith('/')) return filePath;
+  // Home dir shortcut
+  if (filePath.startsWith('~')) return filePath.replace(/^~/, process.env.HOME || '/Users/jinhan');
+  // Relative — place in data/ directory
+  const dataDir = getDataDir();
+  mkdirSync(dataDir, { recursive: true });
+  return join(dataDir, filePath);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function resolvePath(filePath: string, cwd?: string): string {
+  if (filePath.startsWith('/')) return filePath;
+  if (filePath.startsWith('~')) return filePath.replace(/^~/, process.env.HOME || '/Users/jinhan');
+  return cwd ? `${cwd}/${filePath}` : filePath;
+}
+
+function getOfficeCLIBinary(): string {
+  const local = getBinPath();
+  if (existsSync(local)) return local;
+  // Fallback to PATH
+  return 'officecli';
+}
+
+async function runOfficeCLI(args: string[], cwd?: string): Promise<{ stdout: string; stderr: string }> {
+  const binary = getOfficeCLIBinary();
+  try {
+    // Use execFile to avoid shell interpretation of special characters
+    const { stdout, stderr } = await execFileAsync(binary, args, {
+      cwd,
+      timeout: 30_000,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return { stdout: stdout.trim(), stderr: stderr.trim() };
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; stdout?: string; message?: string };
+    const stderr = e.stderr?.trim() || '';
+    const stdout = e.stdout?.trim() || '';
+    const message = e.message || String(err);
+    throw new Error(stderr || stdout || message);
+  }
+}
+
+function isOfficeCLIInstalled(): boolean {
+  try {
+    execSync(`${getOfficeCLIBinary()} --version`, { timeout: 5000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getOfficeCLIVersion(): string {
+  try {
+    return execSync(`${getOfficeCLIBinary()} --version`, { timeout: 5000, encoding: 'utf-8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+function ensureFileExists(filePath: string): void {
+  if (!existsSync(filePath)) {
+    throw new Error(`File not found: ${filePath}. Make sure the path is correct and the file exists.`);
+  }
+}
+
+/** Open a URL in the user's default browser. */
+function openBrowser(url: string): void {
+  if (process.platform === 'darwin') {
+    execSync(`open "${url}"`, { timeout: 5000, stdio: 'pipe' });
+  } else if (process.platform === 'win32') {
+    execSync(`start "" "${url}"`, { timeout: 5000, stdio: 'pipe' });
+  } else {
+    execSync(`xdg-open "${url}"`, { timeout: 5000, stdio: 'pipe' });
+  }
+}
+
+/** Start a live preview for a file. Returns the URL or throws on error. */
+async function startPreviewForFile(filePath: string, port?: number): Promise<string> {
+  const resolved = resolveFilePath(filePath);
+  ensureFileExists(resolved);
+
+  // Already running?
+  if (watchProcesses.has(resolved)) {
+    return watchProcesses.get(resolved)!.url;
+  }
+
+  const binary = getOfficeCLIBinary();
+  const args = ['watch', resolved];
+  if (port) args.push('--port', String(port));
+
+  const child = spawn(binary, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+  watchProcesses.set(resolved, { proc: child, url: '(waiting for server to start...)', lastActivity: Date.now() });
+
+  const url = await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error('Timed out waiting for preview server to start (15s).'));
+    }, 15_000);
+
+    let buffer = '';
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString();
+      const match = buffer.match(/https?:\/\/localhost[:/]\d+/);
+      if (match) {
+        clearTimeout(timeout);
+        child.stdout?.off('data', onData);
+        resolve(match[0]);
+      }
+    };
+
+    child.stdout?.on('data', onData);
+
+    child.on('error', (err) => {
+      clearTimeout(timeout);
+      watchProcesses.delete(resolved);
+      reject(err);
+    });
+
+    child.on('exit', (code) => {
+      clearTimeout(timeout);
+      watchProcesses.delete(resolved);
+      if (code && code !== 0) {
+        reject(new Error(`officecli watch exited with code ${code}`));
+      }
+    });
+  });
+
+  const tracked = watchProcesses.get(resolved);
+  if (tracked) tracked.url = url;
+
+  // Start idle checker to auto-stop watch after inactivity
+  startWatchIdleChecker();
+
+  try { openBrowser(url); } catch { /* best-effort */ }
+
+  return url;
+}
+
+/** Map Node.js platform to OfficeCLI platform string. */
+function mapPlatform(): string {
+  const map: Record<string, string> = { darwin: 'mac', linux: 'linux', win32: 'win' };
+  return map[process.platform] || process.platform;
+}
+
+/** Map Node.js arch to OfficeCLI arch string. */
+function mapArch(): string {
+  // OfficeCLI release assets use: arm64, x64
+  const map: Record<string, string> = { arm64: 'arm64', x64: 'x64' };
+  return map[process.arch] || process.arch;
+}
+
+// ── Tool: setup_officecli ─────────────────────────────────────────────────
+
+function registerSetupTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'setup_officecli',
+      title: 'Setup OfficeCLI',
+      description: 'Download and install OfficeCLI binary into the extension directory. Call this when OfficeCLI is not installed and you need to set it up. This is a one-time setup — once installed, all other office tools will work.',
+      inputSchema: { type: 'object', properties: {} },
+      risk: 'medium',
+      async execute() {
+        if (isOfficeCLIInstalled()) {
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                `✅ OfficeCLI is already installed.`,
+                `Version: ${getOfficeCLIVersion()}`,
+                `Location: \`${getOfficeCLIBinary()}\``,
+                '',
+                'No setup needed — all office tools are ready to use.',
+              ].join('\n'),
+            }],
+          };
+        }
+
+        const binDir = getBinDir();
+        const binPath = getBinPath();
+
+        try {
+          mkdirSync(binDir, { recursive: true });
+
+          const os = mapPlatform();
+          const arch = mapArch();
+          const ext = process.platform === 'win32' ? '.exe' : '';
+          const fileName = `officecli-${os}-${arch}${ext}`;
+          const url = `https://github.com/iOfficeAI/OfficeCLI/releases/latest/download/${fileName}`;
+          const tmpPath = `${binDir}/${fileName}`;
+
+          // Download the binary directly (not an archive)
+          execSync(
+            `curl -fSL -o "${tmpPath}" "${url}"`,
+            { timeout: 120_000, stdio: 'pipe', shell: 'bash' },
+          );
+
+          // Verify download succeeded
+          if (!existsSync(tmpPath)) {
+            throw new Error(`Download failed: ${tmpPath} not found`);
+          }
+
+          // Move to expected location if different
+          if (tmpPath !== binPath) {
+            execSync(`mv "${tmpPath}" "${binPath}"`, { stdio: 'pipe' });
+          }
+
+          // Make executable
+          if (existsSync(binPath)) {
+            chmodSync(binPath, 0o755);
+          }
+
+          if (!existsSync(binPath)) {
+            throw new Error(`Binary not found at ${binPath} after download.`);
+          }
+
+          const version = getOfficeCLIVersion();
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                `✅ OfficeCLI installed successfully!`,
+                `Version: ${version}`,
+                `Location: \`${binPath}\``,
+                '',
+                'All office tools are now ready to use.',
+              ].join('\n'),
+            }],
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                `❌ Failed to install OfficeCLI: ${message}`,
+                '',
+                '**Manual install alternatives:**',
+                '```bash',
+                'curl -fsSL https://d.officecli.ai/install.sh | bash',
+                '```',
+                'or `brew install officecli` or `npm install -g @officecli/officecli`',
+                '',
+                'After installing, restart Finch or re-enable the extension.',
+              ].join('\n'),
+            }],
+            isError: true,
+          };
+        }
+      },
+    }),
+  );
+}
+
+// ── Tool: check_officecli ─────────────────────────────────────────────────
+
+function registerCheckTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'check_officecli',
+      title: 'Check OfficeCLI',
+      description: 'Check whether OfficeCLI is installed and show available tools. Call this first before using any other office tools.',
+      inputSchema: { type: 'object', properties: {} },
+      risk: 'low',
+      async execute() {
+        const binPath = getBinPath();
+
+        if (!isOfficeCLIInstalled()) {
+          const localExists = existsSync(binPath);
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                '**OfficeCLI is not available.**',
+                localExists
+                  ? `Binary exists at \`${binPath}\` but may not be executable. Try calling \`setup_officecli\` to reinstall.`
+                  : `Not found in PATH or at \`${binPath}\`.`,
+                '',
+                '**To install, call the `setup_officecli` tool.**',
+                '',
+                '**Manual install alternatives:**',
+                '```bash',
+                'curl -fsSL https://d.officecli.ai/install.sh | bash',
+                '```',
+                'or `brew install officecli` or `npm install -g @officecli/officecli`',
+              ].join('\n'),
+            }],
+          };
+        }
+
+        const version = getOfficeCLIVersion();
+        const binary = getOfficeCLIBinary();
+        const location = binary === 'officecli' ? 'PATH (installed via brew/npm/manual install)' : `\`${binary}\``;
+        return {
+          content: [{
+            type: 'text',
+            text: [
+              `✅ OfficeCLI is installed.`,
+              `Version: ${version}`,
+              `Location: ${location}`,
+              '',
+              '**Strategy — work top-down:**',
+              '1. `read_office_file` — inspect document structure (outline/html/text/issues/stats)',
+              '2. `get_office_element` — drill into specific elements with `--depth N`',
+              '3. `modify_office_file` — add/set/remove/move elements, find & replace',
+              '4. `save_office_file` — flush changes to disk when done',
+              '',
+              '**When unsure about property names, value formats, or syntax:**',
+              'Run `inspect_office_file` with `action=help` and a `helpQuery` to look up the exact schema.',
+              'Example: `officecli help pptx shape` lists all shape properties.',
+              '',
+              '**Available tools:**',
+              '- `read_office_file` — view document content',
+              '- `create_office_file` — create new Office files',
+              '- `modify_office_file` — add, set, remove, move elements, find & replace',
+              '- `get_office_element` — get structured JSON for any element',
+              '- `inspect_office_file` — validate, run help queries',
+              '- `preview_office_file` — live preview in browser + click-to-select elements',
+              '- `save_office_file` — save and close a file',
+            ].join('\n'),
+          }],
+        };
+      },
+    }),
+  );
+}
+
+// ── Tool: read_office_file ────────────────────────────────────────────────
+
+function registerReadTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'read_office_file',
+      title: 'Read Office File',
+      description: 'Read content from a Word (.docx), Excel (.xlsx), or PowerPoint (.pptx) file. This is your L1 (first-layer) inspection tool.\n\n' +
+        '**View modes:**\n' +
+        '- `outline` — Document structure (headings, slides, sheets, cell values). Best for understanding the overall document.\n' +
+        '- `html` — Static HTML snapshot of the rendered document. Best for seeing layout and formatting.\n' +
+        '- `text` — Plain text extraction. Best for getting just the words.\n' +
+        '- `issues` — Formatting/content/structure problems. Use `--limit N` to cap results.\n' +
+        '- `stats` — Document statistics (pages, words, shapes, etc.).\n' +
+        '- `annotated` — Text with formatting annotations.\n\n' +
+        '**Usage flow:** Start with `outline` to understand structure, then drill deeper with `get_office_element`.\n' +
+        'Use `html` mode for a visual preview of the rendered document.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          filePath: { type: 'string', description: 'Path to the .docx, .xlsx, or .pptx file. Relative or absolute.' },
+          viewMode: { type: 'string', enum: ['outline', 'html', 'text', 'issues', 'stats', 'annotated'], description: 'View mode (default: outline).' },
+          limit: { type: 'number', description: 'Max results for issues mode (e.g. 10).' },
+        },
+        required: ['filePath'],
+      },
+      risk: 'low',
+      async execute(input: Record<string, unknown>) {
+        const { filePath, viewMode = 'outline', limit } = input as { filePath: string; viewMode?: string; limit?: number };
+        const resolved = resolveFilePath(filePath);
+        ensureFileExists(resolved);
+
+        const args = ['view', resolved, viewMode];
+        if (limit != null && viewMode === 'issues') {
+          args.push('--limit', String(limit));
+        }
+
+        const { stdout } = await runOfficeCLI(args);
+        const modeLabel = viewMode.charAt(0).toUpperCase() + viewMode.slice(1);
+
+        return {
+          content: [{
+            type: 'text',
+            text: [
+              `📄 ${filePath} — ${modeLabel}`,
+              '',
+              stdout || '(empty)',
+            ].join('\n'),
+          }],
+        };
+      },
+    }),
+  );
+}
+
+// ── Tool: create_office_file ──────────────────────────────────────────────
+
+function registerCreateTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'create_office_file',
+      title: 'Create Office File',
+      description: 'Create a new Word (.docx), Excel (.xlsx), or PowerPoint (.pptx) file. File type is inferred from the extension.\n\n' +
+        'After creation:\n' +
+        '- PPT: auto-starts live preview in browser\n' +
+        '- Word/Excel: asks user if they want live preview\n\n' +
+        'OfficeCLI auto-starts a resident session on first access (60s idle timeout), ' +
+        'so subsequent edits are fast with no file I/O overhead.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          filePath: { type: 'string', description: 'Path for the new file, e.g. "report.docx", "data.xlsx", "deck.pptx". Extension determines file type.' },
+        },
+        required: ['filePath'],
+      },
+      risk: 'medium',
+      async execute(input: Record<string, unknown>) {
+        const { filePath } = input as { filePath: string };
+        const resolved = resolveFilePath(filePath);
+
+        if (existsSync(resolved)) {
+          return { content: [{ type: 'text', text: `File already exists: ${filePath}. Use modify_office_file to edit it, or choose a different path.` }] };
+        }
+
+        await runOfficeCLI(['create', resolved]);
+
+        try {
+          const url = await startPreviewForFile(filePath);
+          openBrowser(url);
+
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                `✅ Created new file: ${filePath}`,
+                '',
+                `👁 Live preview started: ${url}`,
+                '',
+                'The preview has been opened in your browser. Use `modify_office_file` to add content — the browser will auto-refresh.',
+                'When done, call `preview_office_file(action=stop)` to shut down the server.',
+              ].join('\n'),
+            }],
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                `✅ Created new file: ${filePath}`,
+                '',
+                `⚠️ Failed to start preview: ${message}`,
+                '',
+                'Use `read_office_file` to view it, or `modify_office_file` to add content.',
+              ].join('\n'),
+            }],
+          };
+        }
+      },
+    }),
+  );
+}
+
+// ── Tool: modify_office_file ──────────────────────────────────────────────
+
+function registerModifyTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'modify_office_file',
+      title: 'Modify Office File',
+      description: 'Modify elements in an Office file (Word/Excel/PowerPoint). This is your L2 (DOM-level) editing tool.\n\n' +
+        '**Commands:**\n' +
+        '- `add` — Add new elements (slides, shapes, cells, sheets, paragraphs, tables, charts, etc.)\n' +
+        '- `set` — Modify properties of existing elements (text, font, color, position, bold, etc.)\n' +
+        '- `remove` — Remove elements\n' +
+        '- `move` — Move an element to a different parent or position\n' +
+        '- `find-and-replace` — Find and replace text across the document\n\n' +
+        '**Element paths** (1-based, XPath-style):\n' +
+        '- PPT: `/slide[1]`, `/slide[1]/shape[2]`, or `/slide[1]/shape[@name=Title 1]` for stable IDs\n' +
+        '- Excel: `/Sheet1`, `/Sheet1/A1`, `/Sheet1/row[3]/cell[B]`\n' +
+        '- Word: `/body/p[3]`, `/body/table[1]/row[1]/cell[2]`\n' +
+        '- Root: `/` for document-level properties\n\n' +
+        '**Element types** (for `add`):\n' +
+        '- PPT: `slide`, `shape`, `table`, `chart`, `picture`, `textbox`, `connector`, `group`, `animation`, `transition`\n' +
+        '- Excel: `sheet`, `row`, `cell`, `table`, `chart`, `pivotTable`, `picture`, `sparkline`, `comment`\n' +
+        '- Word: `paragraph`, `run`, `table`, `picture`, `shape`, `textbox`, `chart`, `section`, `header`, `footer`, `comment`, `bookmark`, `hyperlink`\n\n' +
+        '**Props** (key=value):\n' +
+        '- Text: `text`, `title`, `font`, `size`, `bold=true`, `italic=true`, `color=FF0000`, `highlight=yellow`\n' +
+        '- Position: `x`, `y`, `w`, `h` with units like `cm`, `pt`, `px`\n' +
+        '- Colors: hex (`FF0000`), named (`red`), theme (`accent1`)\n' +
+        '- Excel cells: `value`, `formula=SUM(A1:A10)`, `bold=true`, `numberFormat=#,##0`\n' +
+        '- Spacing: `12pt`, `0.5cm`, `1.5x`\n' +
+        '- Dotted aliases: `font.color=red`, `font.bold=true`, `font.size=14pt`\n\n' +
+        '**Find & Replace** (set command with `find`/`replace`):\n' +
+        'Set `command=set` and include `find` and `replace` in props to do find-and-replace.\n' +
+        'Example: props={"find":"draft","replace":"final"} finds "draft" across the document and replaces it with "final".\n' +
+        'Use `regex=true` in props for regex matching.\n\n' +
+        '**Clone existing elements:**\n' +
+        'Set `command=add` and include `from` in props to clone an element.\n' +
+        'Example: props={"from":"/slide[1]"} clones the first slide.\n\n' +
+        '**IMPORTANT — When unsure about property names, value formats, or command syntax:**\n' +
+        'Run `inspect_office_file` with `helpQuery` set to look up the exact schema.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          filePath: { type: 'string', description: 'Path to the .docx, .xlsx, or .pptx file.' },
+          command: { type: 'string', enum: ['add', 'set', 'remove', 'move'], description: 'Operation: add (create new), set (modify), remove (delete), move (reposition).' },
+          elementPath: { type: 'string', description: 'Path to the target element. E.g. "/" (root), "/slide[1]", "/slide[1]/shape[2]", "/Sheet1/A1", "/body/p[3]". For add, this is the parent where the new element goes.' },
+          elementType: { type: 'string', description: 'Element type to add (required for add command). E.g. "slide", "shape", "paragraph", "run", "table", "chart", "picture", "sheet", "row", "cell", "pivotTable", "comment", "section".' },
+          props: {
+            type: 'object',
+            description: 'Key-value properties. Examples: {"title":"Q4 Report","text":"Hello","font":"Arial","size":24,"color":"FFFFFF","bold":true,"background":"1A1A2E","x":"2cm","y":"5cm"}. For find/replace: {"find":"draft","replace":"final"} or {"find":"\\d+%","regex":true,"replace":"[redacted]"} on the root path "/". For clone: {"from":"/slide[1]"} on add command. For Excel: {"value":123,"formula":"SUM(A1:A10)"}.',
+            properties: {},
+            additionalProperties: true,
+          },
+          targetPath: { type: 'string', description: 'For move command: destination parent path. For add with --after/--before: anchor element path. Optional.' },
+        },
+        required: ['filePath', 'command', 'elementPath'],
+      },
+      risk: 'medium',
+      async execute(input: Record<string, unknown>) {
+        const { filePath, command, elementPath, elementType, props, targetPath } = input as {
+          filePath: string;
+          command: string;
+          elementPath: string;
+          elementType?: string;
+          props?: Record<string, string | number | boolean>;
+          targetPath?: string;
+        };
+
+        const resolved = resolveFilePath(filePath);
+        if (command !== 'add') {
+          ensureFileExists(resolved);
+        }
+
+        const args = [command, resolved, elementPath];
+
+        if (elementType && command === 'add') {
+          args.push('--type', elementType);
+        }
+
+        if (targetPath) {
+          if (command === 'move') {
+            args.push('--to', targetPath);
+          } else {
+            args.push('--after', targetPath);
+          }
+        }
+
+        if (props && typeof props === 'object' && Object.keys(props).length > 0) {
+          for (const [key, value] of Object.entries(props)) {
+            const strVal = String(value);
+            args.push('--prop', `${key}=${strVal}`);
+          }
+        }
+
+        const { stdout, stderr } = await runOfficeCLI(args);
+
+        // Touch watch activity if preview is running for this file
+        touchWatchActivity(resolved);
+
+        // If no preview running, start one
+        let previewInfo = '';
+        if (!watchProcesses.has(resolved)) {
+          try {
+            const url = await startPreviewForFile(filePath);
+            previewInfo = `\n\n👁 Live preview started: ${url}`;
+          } catch {
+            // Preview failed to start — not critical, just skip
+          }
+        }
+
+        return {
+          content: [{
+            type: 'text',
+            text: [
+              `✅ ${command} on ${filePath} (path: ${elementPath})`,
+              stderr ? `\n${stderr}` : '',
+              stdout ? `\n${stdout}` : '',
+              previewInfo,
+            ].filter(Boolean).join(''),
+          }],
+        };
+      },
+    }),
+  );
+}
+
+// ── Tool: get_office_element ──────────────────────────────────────────────
+
+function registerGetTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'get_office_element',
+      title: 'Get Office Element',
+      description: 'Get detailed structured information (JSON) about a specific element in an Office file. ' +
+        'Use this to inspect element properties, cell values, formulas, styles, positions, etc. ' +
+        'Use `--depth N` to expand N levels of children.\n\n' +
+        '**Examples:**\n' +
+        '- `get data.xlsx /Sheet1/B2 --json` — get a single cell\'s value and properties\n' +
+        '- `get deck.pptx \'/slide[1]\' --depth 1` — list all shapes on slide 1\n' +
+        '- `get report.docx /` — full document structure\n' +
+        '- `get report.docx \'/body/p[3]\' --depth 2 --json` — paragraph with children\n\n' +
+        '**Stable ID addressing:** Elements with stable IDs return paths like `/slide[1]/shape[@id=550950021]` ' +
+        'which persist across insert/delete operations (unlike positional indices).\n\n' +
+        'Use this before modifying an element to see its current state.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          filePath: { type: 'string', description: 'Path to the .docx, .xlsx, or .pptx file.' },
+          elementPath: { type: 'string', description: 'Path to the element. Use "/" for full document. E.g. "/slide[1]", "/slide[1]/shape[1]", "/Sheet1/B2", "/body/p[3]". Also supports stable IDs: "/slide[1]/shape[@id=550950021]".' },
+          depth: { type: 'number', description: 'How many levels of children to expand (default: 1). Use 0 for just the element itself, 2+ for deeper children.' },
+        },
+        required: ['filePath', 'elementPath'],
+      },
+      risk: 'low',
+      async execute(input: Record<string, unknown>) {
+        const { filePath, elementPath, depth } = input as { filePath: string; elementPath: string; depth?: number };
+        const resolved = resolveFilePath(filePath);
+        ensureFileExists(resolved);
+
+        const args = ['get', resolved, elementPath, '--json'];
+        if (depth != null) {
+          args.push('--depth', String(depth));
+        }
+
+        const { stdout } = await runOfficeCLI(args);
+
+        try {
+          const parsed = JSON.parse(stdout);
+          const depthInfo = depth != null ? ` (depth=${depth})` : '';
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                `📋 ${filePath} → ${elementPath}${depthInfo}`,
+                '',
+                '```json',
+                JSON.stringify(parsed, null, 2),
+                '```',
+              ].join('\n'),
+            }],
+          };
+        } catch {
+          return { content: [{ type: 'text', text: stdout || '(no output)' }] };
+        }
+      },
+    }),
+  );
+}
+
+// ── Tool: inspect_office_file ─────────────────────────────────────────────
+
+function registerInspectTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'inspect_office_file',
+      title: 'Inspect Office File',
+      description: 'Run diagnostics, validation, or help queries for Office files.\n\n' +
+        '**Actions:**\n' +
+        '- `validate` — Validate the file against the OpenXML schema. Catches structural issues.\n' +
+        '- `help` — Query the OfficeCLI help system for property names, value formats, and syntax.\n' +
+        '  Use this when you are unsure about command syntax instead of guessing.\n\n' +
+        '**Help query examples:**\n' +
+        '- `officecli help` — list all commands\n' +
+        '- `officecli help pptx` — list all PPTX element types\n' +
+        '- `officecli help pptx shape` — full shape schema with properties, aliases, examples\n' +
+        '- `officecli help docx paragraph` — paragraph properties\n' +
+        '- `officecli help xlsx cell` — cell properties, value formats\n' +
+        '- `officecli help pptx set shape` — only props usable with the `set` command\n' +
+        '- `officecli help pptx shape --json` — structured machine-readable schema\n\n' +
+        '**Format aliases:** `word`→`docx`, `excel`→`xlsx`, `ppt`/`powerpoint`→`pptx`.\n\n' +
+        '**IMPORTANT:** When you are unsure about property names, value formats, or command syntax, ' +
+        'ALWAYS run a help query here instead of guessing. One help query beats guess-fail-retry loops.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          filePath: { type: 'string', description: 'Path to the file to validate. Only needed for validate action.' },
+          action: { type: 'string', enum: ['validate', 'help'], description: 'Action: validate the file or query the help system.' },
+          helpQuery: { type: 'string', description: 'For help action: the help query string. E.g. "pptx shape", "docx paragraph", "xlsx cell", "pptx", "". Empty string = general help.' },
+        },
+        required: ['action'],
+      },
+      risk: 'low',
+      async execute(input: Record<string, unknown>) {
+        const { filePath, action, helpQuery } = input as { filePath?: string; action: string; helpQuery?: string };
+
+        if (action === 'help') {
+          const args = ['help'];
+          if (helpQuery) {
+            args.push(helpQuery);
+          }
+          const { stdout } = await runOfficeCLI(args);
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                '📖 OfficeCLI Help',
+                helpQuery ? `Query: \`officecli help ${helpQuery}\`` : 'General help',
+                '',
+                '```',
+                stdout || '(no output)',
+                '```',
+                '',
+                '**Tip:** For more specific help, run again with a more targeted query like `pptx shape`, `docx paragraph`, or `xlsx cell`.',
+              ].join('\n'),
+            }],
+          };
+        }
+
+        if (!filePath) {
+          return { content: [{ type: 'text', text: 'filePath is required for validate action.' }], isError: true };
+        }
+        const resolved = resolveFilePath(filePath);
+        ensureFileExists(resolved);
+
+        const { stdout } = await runOfficeCLI(['validate', resolved]);
+        return {
+          content: [{
+            type: 'text',
+            text: [
+              `🔍 Validation result for ${filePath}`,
+              '',
+              stdout || 'No issues found — file is valid.',
+            ].join('\n'),
+          }],
+        };
+      },
+    }),
+  );
+}
+
+// ── Tool: save_office_file ────────────────────────────────────────────────
+
+function registerSaveTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'save_office_file',
+      title: 'Save Office File',
+      description: 'Save and close an Office file. Flushes the resident session to disk.\n\n' +
+        'OfficeCLI auto-starts a resident session on first file access (60s idle timeout). ' +
+        'Its own reads (get/query/view) always see the latest edits, so you generally do NOT need to ' +
+        'save mid-workflow. Call this only when:\n' +
+        '- You are done editing the file\n' +
+        '- A non-officecli program needs to read the file (e.g. Word, Excel, PowerPoint, a renderer)\n' +
+        '- You want to explicitly release the file handle',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          filePath: { type: 'string', description: 'Path to the .docx, .xlsx, or .pptx file to save and close.' },
+        },
+        required: ['filePath'],
+      },
+      risk: 'low',
+      async execute(input: Record<string, unknown>) {
+        const { filePath } = input as { filePath: string };
+        const resolved = resolveFilePath(filePath);
+        ensureFileExists(resolved);
+
+        const { stdout } = await runOfficeCLI(['close', resolved]);
+        return {
+          content: [{
+            type: 'text',
+            text: `✅ Saved and closed: ${filePath}${stdout ? '\n' + stdout : ''}`,
+          }],
+        };
+      },
+    }),
+  );
+}
+
+// ── Tool: preview_office_file ─────────────────────────────────────────────
+
+function registerPreviewTool(ctx: finch.MiniToolContext): void {
+  ctx.subscriptions.push(
+    ctx.tools.register({
+      name: 'preview_office_file',
+      title: 'Preview Office File',
+      description: 'Start, stop, or read selected elements from a live HTML preview of an Office file.\n\n' +
+        '**Actions:**\n' +
+        '- `start` — Launch a live preview server (default port 26315). The browser auto-refreshes on every file change. ' +
+        'You and the user can click elements in the browser to select them, then use `action=selected` to inspect them.\n' +
+        '- `stop` — Shut down the preview server for the given file.\n' +
+        '- `selected` — Get structured JSON for whatever element the user clicked in the browser preview.\n\n' +
+        '**Workflow:**\n' +
+        '1. Start preview: `preview_office_file(action=start, filePath=deck.pptx)`\n' +
+        '2. Open the returned URL in browser\n' +
+        '3. After the user clicks an element: `preview_office_file(action=selected, filePath=deck.pptx)`\n' +
+        '4. Use the returned path with `modify_office_file` to edit it\n' +
+        '5. Stop preview when done: `preview_office_file(action=stop, filePath=deck.pptx)`',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          filePath: { type: 'string', description: 'Path to the .docx, .xlsx, or .pptx file.' },
+          action: { type: 'string', enum: ['start', 'stop', 'selected'], description: 'start: launch live preview. stop: shut down preview. selected: get the currently selected element in the browser.' },
+          port: { type: 'number', description: 'Port for the preview server (default: 26315). Only used with start action.' },
+        },
+        required: ['filePath', 'action'],
+      },
+      risk: 'low',
+      async execute(input: Record<string, unknown>) {
+        const { filePath, action, port } = input as { filePath: string; action: string; port?: number };
+        const resolved = resolveFilePath(filePath);
+        ensureFileExists(resolved);
+
+        // ── selected: read browser selection ──
+        if (action === 'selected') {
+          const { stdout } = await runOfficeCLI(['get', resolved, 'selected', '--json']);
+
+          if (!stdout) {
+            return { content: [{ type: 'text', text: 'No element is currently selected in the browser. Click an element in the preview first.' }] };
+          }
+
+          try {
+            const parsed = JSON.parse(stdout);
+            return {
+              content: [{
+                type: 'text',
+                text: [
+                  '🎯 Selected element:',
+                  '',
+                  '```json',
+                  JSON.stringify(parsed, null, 2),
+                  '```',
+                  '',
+                  'Use `modify_office_file` with the returned `path` to edit the selected element.',
+                ].join('\n'),
+              }],
+            };
+          } catch {
+            return { content: [{ type: 'text', text: stdout }] };
+          }
+        }
+
+        // ── stop: shut down preview server ──
+        if (action === 'stop') {
+          // Kill tracked process if we have it
+          const tracked = watchProcesses.get(resolved);
+          if (tracked) {
+            tracked.proc.kill();
+            watchProcesses.delete(resolved);
+          }
+          // Also send unwatch command
+          try {
+            await runOfficeCLI(['unwatch', resolved]);
+          } catch {
+            // unwatch may fail if already stopped — not an error
+          }
+          return { content: [{ type: 'text', text: `⏹ Preview stopped for ${filePath}` }] };
+        }
+
+        // ── start: launch watch server ──
+        try {
+          const url = await startPreviewForFile(filePath, port);
+          return {
+            content: [{
+              type: 'text',
+              text: [
+                `👁 Preview started for ${filePath}`,
+                '',
+                `URL: ${url}`,
+                '',
+                'The preview has been opened in your browser. Click elements to select them,',
+                'then call this tool again with `action=selected` to inspect the selection.',
+                'When done, call `action=stop` to shut down the server.',
+              ].join('\n'),
+            }],
+          };
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          return {
+            content: [{
+              type: 'text',
+              text: `❌ Failed to start preview for ${filePath}: ${message}`,
+            }],
+            isError: true,
+          };
+        }
+      },
+    }),
+  );
+}
+
+// ── Activation ────────────────────────────────────────────────────────────
+
+export function activate(ctx: finch.MiniToolContext): void {
+  // Store extension path for local binary resolution
+  _extensionPath = ctx.extension.extensionPath;
+
+  ctx.logger.info(`office-tools activating (extension path: ${_extensionPath})`);
+
+  registerCheckTool(ctx);
+  registerSetupTool(ctx);
+  registerReadTool(ctx);
+  registerCreateTool(ctx);
+  registerModifyTool(ctx);
+  registerGetTool(ctx);
+  registerInspectTool(ctx);
+  registerPreviewTool(ctx);
+  registerSaveTool(ctx);
+
+  ctx.logger.info('office-tools activated — 9 tools registered');
+}
+
+export function deactivate(): void {
+  // Kill all running watch processes
+  for (const [file, tracked] of watchProcesses) {
+    try {
+      tracked.proc.kill();
+    } catch {
+      // ignore
+    }
+  }
+  watchProcesses.clear();
+}

--- a/extensions/office-tools/tsconfig.json
+++ b/extensions/office-tools/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": false,
+    "sourceMap": false,
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "finch": ["./node_modules/@finch.app/minitool-api/finch.d.ts"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

新增 Office Tools 扩展，让 Finch Agent 能够读取、创建、编辑 Word、Excel、PowerPoint 文件。底层使用 OfficeCLI。

## 9 个 Agent Tools

- `setup_officecli` — 下载安装 OfficeCLI（一次性）
- `check_officecli` — 检查安装状态
- `read_office_file` — 读取文件（大纲/HTML/纯文本/问题/统计）
- `create_office_file` — 创建文件 + 自动启动实时预览
- `modify_office_file` — 增/改/删/移动元素，查找替换
- `get_office_element` — 获取元素 JSON
- `inspect_office_file` — 校验文件、查询帮助
- `preview_office_file` — 实时预览 + 点击选择元素
- `save_office_file` — 保存并关闭

## 核心能力

- OfficeCLI 自动安装：首次使用时下载到扩展 bin/ 目录
- 实时预览：创建文件后自动启动 watch，浏览器实时刷新
- 空闲超时：5 分钟无修改自动停止 watch
- 跨平台：macOS (arm64/x64)、Linux、Windows
- i18n：中英文双语（systemPrompt + 34 个 promptGuides）
- 特殊字符：execFile 替代 exec，避免 shell 解释分号/换行符

## 34 个 PromptGuides

- Word：报告、会议纪要、提案、合同、简历、表格、图片、批注、批量替换
- Excel：预算、销售仪表盘、透视表、成绩册、财务模型、项目追踪、公式图表
- PPT：Pitch Deck、季度回顾、产品发布、培训、数据可视化、动画、批量修改

## Testing

- 安装测试通过
- OfficeCLI 自动下载（macOS arm64）
- 创建/编辑 PPT、Word、Excel
- 实时预览 + 浏览器刷新
- 特殊字符处理（分号、换行符、中文引号）
- 空闲超时自动停止
