### PR TITLE
fix: narrow chrome-devtools lockfile ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 
 # Node.js
 node_modules/
-extensions/*/package-lock.json
+extensions/chrome-devtools/package-lock.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
## Summary
- Replace broad `extensions/*/package-lock.json` ignore rule with `extensions/chrome-devtools/package-lock.json`
- Keep other extension package-lock files trackable when needed

## Notes
- Chrome DevTools MCP remains pinned to `chrome-devtools-mcp@1.5.0` and is launched via npx at runtime.
