### PR TITLE
feat: add Finch Pet to community registry

### DIFF
--- a/community/mini-tools.json
+++ b/community/mini-tools.json
@@ -42,7 +42,7 @@
   },
   {
     "id": "finch-pet",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "name": "Finch Pet",
     "author": "Kassell",
     "description": "A desktop pet for Finch that reacts to agent status and supports Petdex-compatible pet imports.",

--- a/community/mini-tools.json
+++ b/community/mini-tools.json
@@ -42,7 +42,7 @@
   },
   {
     "id": "finch-pet",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "name": "Finch Pet",
     "author": "Kassell",
     "description": "A desktop pet for Finch that reacts to agent status and supports Petdex-compatible pet imports.",

--- a/community/mini-tools.json
+++ b/community/mini-tools.json
@@ -42,7 +42,7 @@
   },
   {
     "id": "finch-pet",
-    "version": "1.0.1",
+    "version": "1.0.4",
     "name": "Finch Pet",
     "author": "Kassell",
     "description": "A desktop pet for Finch that reacts to agent status and supports Petdex-compatible pet imports.",

--- a/community/mini-tools.json
+++ b/community/mini-tools.json
@@ -41,6 +41,20 @@
     "featured": true
   },
   {
+    "id": "finch-pet",
+    "version": "1.0.0",
+    "name": "Finch Pet",
+    "author": "Kassell",
+    "description": "A desktop pet for Finch that reacts to agent status and supports Petdex-compatible pet imports.",
+    "repo": "Kassell/finch-pet",
+    "npm": "finch-pet",
+    "extensionType": "community",
+    "categories": [
+      "productivity"
+    ],
+    "featured": false
+  },
+  {
     "id": "frontend-design",
     "version": "0.1.1",
     "name": "Frontend Design",

--- a/community/mini-tools.zh-CN.json
+++ b/community/mini-tools.zh-CN.json
@@ -15,6 +15,11 @@
     "description": "通过 MCP 连接 Chrome DevTools，让 Finch 检查、调试和操作 Chrome 页面。"
   },
   {
+    "id": "finch-pet",
+    "name": "Finch 桌宠",
+    "description": "住在桌面上的 Finch 宠物，可响应 Agent 状态，并支持导入兼容 Petdex 的宠物包。"
+  },
+  {
     "id": "frontend-design",
     "name": "网页设计",
     "description": "通过内嵌设计技能创建具有鲜明风格、可用于生产的前端界面。"


### PR DESCRIPTION
## Summary

- add Finch Pet to the community extension registry
- set `finch-pet` to the latest npm version `1.0.4`

## Validation

- `python3 .finch/skills/community-manager/scripts/validate.py`
- 90 checks passed, 0 errors
- 5 expected warnings for community extensions without local source directories
