### PR TITLE
chore: update finch-chrome-devtools to 1.5.2

### DIFF
--- a/community/mini-tools.json
+++ b/community/mini-tools.json
@@ -28,7 +28,7 @@
   },
   {
     "id": "chrome-devtools",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "name": "Chrome DevTools",
     "author": "Kassell",
     "description": "Connect Chrome DevTools through MCP for browser automation, debugging, Lighthouse audits, performance traces, and more.",


### PR DESCRIPTION
## Summary

- update `finch-chrome-devtools` in the community extension registry from `1.5.0` to `1.5.2`

## Validation

- `python3 .finch/skills/community-manager/scripts/validate.py`
- 90 checks passed, 0 errors
- 5 expected warnings for community extensions without local source directories
