### PR TITLE
fix(deps): 升级 agently-mail 的 fast-uri 依赖修复 CVE-2026-16221

### DIFF
--- a/extensions/agently-mail/package-lock.json
+++ b/extensions/agently-mail/package-lock.json
@@ -468,9 +468,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",

--- a/extensions/agently-mail/package.json
+++ b/extensions/agently-mail/package.json
@@ -84,6 +84,9 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
+  "overrides": {
+    "fast-uri": "^3.1.7"
+  },
   "devDependencies": {
     "@finchtoys/minitool-api": "^0.2.9",
     "@types/node": "^26.1.0",


### PR DESCRIPTION
Fixes #67

将 `extensions/agently-mail` 中传递依赖 `fast-uri` 升级到 3.1.7（通过 `overrides` 锁定），修复 fast-uri 2.3.1–4.1.0（含 3.1.3）在解析 URL 时不把反斜杠视为 authority 分隔符、与 Node 原生 WHATWG URL 解析结果不一致的问题，避免被利用绕过 host 校验（SSRF/allowlist/denylist）。

## 验证
- `npm install --ignore-scripts` 通过
- `npm run build` 通过
- `package-lock.json` 中 `fast-uri` 已确认为 3.1.7
